### PR TITLE
docs(readme): adds shell agnostic usage

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -54,6 +54,15 @@
       "contributions": [
         "example"
       ]
+    },
+    {
+      "login": "edm00se",
+      "name": "Eric McCormick",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/622118?v=4",
+      "profile": "https://edm00se.codes/",
+      "contributions": [
+        "doc"
+      ]
     }
   ],
   "repoType": "github"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ beautifully :)</p>
 [![version][version-badge]][package] [![downloads][downloads-badge]][npmtrends]
 [![MIT License][license-badge]][license]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-5-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-6-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs] [![Code of Conduct][coc-badge]][coc]
 
 ## The problem
@@ -36,6 +36,7 @@ handles the redirecting for you.
 - [Installation](#installation)
 - [Usage](#usage)
 - [Shell Function](#shell-function)
+  - [Shell Agnostic](#shell-agnostic)
   - [Bash](#bash)
   - [Fish](#fish)
   - [Windows (cmd)](#windows-cmd)
@@ -111,6 +112,22 @@ by the time you've shared it to someone.
 If you want to be able to run this anywhere in the terminal, you can try making
 a custom function for your shell.
 
+### Shell Agnostic
+
+1. Add the following [executable definition][npm-bin] to your `package.json`:
+    ```json
+    { "bin" : { "shorten" : "cli.js" } }
+    ```
+2. Create the `cli.js` file:
+    ```js
+    #!/usr/bin/env node
+    require('netlify-shortener');
+    ```
+3. From your project directory, run the following to register the command globally:
+    ```sh
+    npm link
+    ```
+
 ### Bash
 
 Place this in your `~/.bash_profile` file:
@@ -181,9 +198,8 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 <!-- prettier-ignore -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/netlify-shortener/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/netlify-shortener/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/netlify-shortener/commits?author=kentcdodds "Tests") | [<img src="https://avatars0.githubusercontent.com/u/2036823?v=4" width="100px;"/><br /><sub><b>Carl Rosell</b></sub>](https://github.com/CarlRosell)<br />[🤔](#ideas-CarlRosell "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/5865?v=4" width="100px;"/><br /><sub><b>Phil Hawksworth</b></sub>](http://hawksworx.com)<br />[🤔](#ideas-philhawksworth "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/2480667?v=4" width="100px;"/><br /><sub><b>Matt Ferderer</b></sub>](http://mattferderer.com)<br />[📖](https://github.com/kentcdodds/netlify-shortener/commits?author=mattferderer "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/25517624?v=4" width="100px;"/><br /><sub><b>Jed Fox</b></sub>](https://j-f1.github.io)<br />[💡](#example-j-f1 "Examples") |
-| :---: | :---: | :---: | :---: | :---: |
-
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;" alt="Kent C. Dodds"/><br /><sub><b>Kent C. Dodds</b></sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/netlify-shortener/commits?author=kentcdodds "Code") [📖](https://github.com/kentcdodds/netlify-shortener/commits?author=kentcdodds "Documentation") [🚇](#infra-kentcdodds "Infrastructure (Hosting, Build-Tools, etc)") [⚠️](https://github.com/kentcdodds/netlify-shortener/commits?author=kentcdodds "Tests") | [<img src="https://avatars0.githubusercontent.com/u/2036823?v=4" width="100px;" alt="Carl Rosell"/><br /><sub><b>Carl Rosell</b></sub>](https://github.com/CarlRosell)<br />[🤔](#ideas-CarlRosell "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/5865?v=4" width="100px;" alt="Phil Hawksworth"/><br /><sub><b>Phil Hawksworth</b></sub>](http://hawksworx.com)<br />[🤔](#ideas-philhawksworth "Ideas, Planning, & Feedback") | [<img src="https://avatars3.githubusercontent.com/u/2480667?v=4" width="100px;" alt="Matt Ferderer"/><br /><sub><b>Matt Ferderer</b></sub>](http://mattferderer.com)<br />[📖](https://github.com/kentcdodds/netlify-shortener/commits?author=mattferderer "Documentation") | [<img src="https://avatars2.githubusercontent.com/u/25517624?v=4" width="100px;" alt="Jed Fox"/><br /><sub><b>Jed Fox</b></sub>](https://j-f1.github.io)<br />[💡](#example-j-f1 "Examples") | [<img src="https://avatars3.githubusercontent.com/u/622118?v=4" width="100px;" alt="Eric McCormick"/><br /><sub><b>Eric McCormick</b></sub>](https://edm00se.codes/)<br />[📖](https://github.com/kentcdodds/netlify-shortener/commits?author=edm00se "Documentation") |
+| :---: | :---: | :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.
@@ -218,3 +234,4 @@ MIT
 [twitter-badge]: https://img.shields.io/twitter/url/https/github.com/kentcdodds/netlify-shortener.svg?style=social
 [emojis]: https://github.com/kentcdodds/all-contributors#emoji-key
 [all-contributors]: https://github.com/kentcdodds/all-contributors
+[npm-bin]: https://docs.npmjs.com/files/package.json#bin


### PR DESCRIPTION
**What**:

Adds documentation for a shell agnostic global registering of the `shorten` command.

**Why**:

This makes the install for CLI usage somewhat more the "npm way", and eliminates the manual wiring of BASH script, etc.

**How**:

Provides instructions on:

- registering the CLI command in `package.json`
- adding the `cli.js` (_extremely_ thin wrapper for the shortener `dist/index.js`)
- performing the `npm link` to make the command available

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests
- [x] Ready to be merged <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [x] Added myself to contributors table <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->
This should take care of #10.