### PR TITLE
Add url sorting

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -38,6 +38,36 @@ test('format formats the redirects links', () => {
 `)
 })
 
+test('format sorts the redirects links', () => {
+  expect(
+    format(`
+# comment 1
+
+/foo https://foo.com
+/example https://example.com
+/kcd https://kentcdodds.com
+/bar https://bar.com
+#comment2
+
+
+/* http://google.com
+  `),
+  ).toMatchInlineSnapshot(`
+"
+# comment1
+
+/bar       https://bar.com
+/example   https://example.com
+/foo       https://foo.com
+/kcd       https://kentcdodds.com
+#comment2
+
+
+/*         http://google.com
+"
+`)
+})
+
 test('validates links are unique', () => {
   expect(() => validateUnique('/foo', `/bar https://bar.com`)).not.toThrow()
   expect(() =>

--- a/src/utils.js
+++ b/src/utils.js
@@ -11,13 +11,21 @@ function format(contents) {
     return length
   }, 0)
 
-  const formattedLinks = links.map(([short, long]) => {
-    if (short.startsWith('/')) {
-      return `${short.padEnd(longestLength, ' ')}   ${long}`
-    } else {
-      return `${short}${long}`
-    }
-  })
+  const formattedLinks = links
+    .sort(([shortA, longA], [shortB, longB]) =>
+      shortA !== '/*' && shortA.startsWith('/') && shortB.startsWith('/')
+        ? longA < longB
+          ? -1
+          : 1
+        : 0,
+    )
+    .map(([short, long]) => {
+      if (short.startsWith('/')) {
+        return `${short.padEnd(longestLength, ' ')}   ${long}`
+      } else {
+        return `${short}${long}`
+      }
+    })
 
   return formattedLinks.join('\n')
 }


### PR DESCRIPTION
**What**: Added lexicographical sorting to URLs

<!-- Why are these changes necessary? -->

**Why**: see #24 

<!-- How were these changes implemented? -->

**How**: Added a sort function just before formatting the links:
the function sorts every line that is considered as a redirect except the fallback redirect `\*` (to keep it in place) based on their URLs. 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [x] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->
- [ ] Added myself to contributors table
      <!-- this is optional, see the contributing guidelines for instructions -->

<!-- feel free to add additional comments -->

Maybe the sorting should not take into account the `https://` - `http://` difference ?

Post TravisCI: Sort implementation changed in node 11, the sort function needs to be able to work in node 10 and 12, but I don't have a clue where to start for this...