### PR TITLE
Fix bug when running shorten with no arguments

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -35,10 +35,10 @@ if (codeRaw) {
 const short = `/${code || generateCode()}`
 const contents = fs.readFileSync(redirectPath, 'utf8')
 
-const formattedLink = addProtocolIfMissing(longLink)
-
 let newContents = contents
-if (formattedLink) {
+let formattedLink = null
+if (longLink) {
+  formattedLink = addProtocolIfMissing(longLink)
   validateUrl(formattedLink)
   validateUnique(short, contents)
   newContents = `${short} ${formattedLink}\n${contents}`


### PR DESCRIPTION
**What**:

This PR fixes an error that is thrown when running shorten with no arguments (to format the redirects file). 

**Why**:

addProtocolIfMissing() was being called on the on the longLink (first) argument from the command line, before checking if it had actually been provided. 

**How**:

index.js now checks for the existence of the first argument before attempted to modify it. 

**Checklist**:

- [ ] Documentation N/A
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table

Additional commments:

No tests currently for non utility function code - should we add some?
