### PR TITLE
Add support for package.json's homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,11 @@ Your project should have a `_redirects` file that looks like this:
 ```
 
 This module exposes a binary that you should use in your `package.json` scripts.
-You also need to add a `baseUrl` to your `package.json`:
+You also need to add a `homepage` to your `package.json`:
 
 ```json
 {
-  "baseUrl": "https://jsair.io",
+  "homepage": "https://jsair.io",
   "scripts": {
     "shorten": "netlify-shortener"
   }
@@ -250,6 +250,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/index.js
+++ b/src/index.js
@@ -15,10 +15,13 @@ const {
   addProtocolIfMissing,
 } = require('./utils')
 
-const {
-  packageJson: {baseUrl = 'https://update-baseUrl-in-your-package.json'},
-  path: pkgPath,
-} = readPkg.sync({cwd: path.join(__dirname, '../..')})
+const {packageJson, path: pkgPath} = readPkg.sync({
+  cwd: path.join(__dirname, '../..'),
+})
+const baseUrl =
+  packageJson.baseUrl ||
+  packageJson.homepage ||
+  'https://update-homepage-in-your-package.json'
 
 const repoRoot = path.dirname(pkgPath)
 const redirectPath = path.join(repoRoot, '_redirects')


### PR DESCRIPTION


<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

This PR adds support for `package.json`'s `homepage` field while still supporting `baseUrl` as the primary source. The documentation has been updated to only mention the `homepage` field.

**Why**:

Following the discussion in #34, the `homepage` field is an official and [documented](https://docs.npmjs.com/files/package.json#homepage) field of the `package.json`.

**How**:

I just added support for the `homepage` field while keeping `baseUrl` the primary source to avoid breaking stuff for the current users.

**Checklist**:

- [x] Documentation
- [ ] Tests N/A
- [x] Ready to be merged
- [ ] Added myself to contributors table N/A

Closes #34