### PR TITLE
Add optional setting to disable commit and push after adding link

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,11 +73,14 @@ Your project should have a `_redirects` file that looks like this:
 ```
 
 This module exposes a binary that you should use in your `package.json` scripts.
-You also need to add a `homepage` to your `package.json`:
+You also need to add a `homepage` to your `package.json`. The optional flag
+`commitAndPush` can be included to disable automatic commit and push after
+adding a link:
 
 ```json
 {
   "homepage": "https://jsair.io",
+  "commitAndPush": false,
   "scripts": {
     "shorten": "netlify-shortener"
   }
@@ -195,6 +198,7 @@ Thanks goes to these people ([emoji key][emojis]):
 
 <!-- markdownlint-enable -->
 <!-- prettier-ignore-end -->
+
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification.

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,8 @@ const baseUrl =
   packageJson.homepage ||
   'https://update-homepage-in-your-package.json'
 
+const doCommitAndPush = packageJson.commitAndPush !== false
+
 const repoRoot = path.dirname(pkgPath)
 const redirectPath = path.join(repoRoot, '_redirects')
 
@@ -32,7 +34,9 @@ const [, , longLink, codeRaw] = process.argv
 
 let code
 if (codeRaw) {
-  code = encodeURIComponent(codeRaw.startsWith('/') ? codeRaw.substring(1) : codeRaw)
+  code = encodeURIComponent(
+    codeRaw.startsWith('/') ? codeRaw.substring(1) : codeRaw,
+  )
 }
 
 const short = `/${code || generateCode()}`
@@ -48,7 +52,10 @@ if (longLink) {
 }
 
 fs.writeFileSync(redirectPath, format(newContents))
-commitAndPush(short, formattedLink, repoRoot)
+
+if (doCommitAndPush) {
+  commitAndPush(short, formattedLink, repoRoot)
+}
 
 const link = `${baseUrl}${short}`
 clipboardy.writeSync(link)


### PR DESCRIPTION
<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:

Add ability to include `commitAndPush` in your `package.json` which determines if a commit and push happens after adding a link. Should default to `true` if not specified.

**Why**:

You can't stop the commit and push if you don't want it to happen.

**How**:
Set `doCommitAndPush` to equal `packageJson.commitAndPush !== false` and check it before doing `commitAndPush()`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [x] Documentation
- [x] Tests (edited the equivalent lines in my `node_modules` and it appeared to work
- [x] Ready to be merged

A few extra lines appear to have changed as a result of automatic pre-commit formatting.

