### PR TITLE
test: Update 'validates url is valid' test

### DIFF
--- a/src/__tests__/utils.js
+++ b/src/__tests__/utils.js
@@ -50,9 +50,11 @@ test('validates links are unique', () => {
 
 test('validates url is valid', () => {
   expect(() => validateUrl('https://blah.com')).not.toThrow()
-  expect(() => validateUrl('blah')).toThrowErrorMatchingInlineSnapshot(
-    `"Invalid URL: blah"`,
-  )
+  expect(() => validateUrl('blah')).toThrow()
+  const urlError1 = 'Invalid URL'
+  const urlError2 = 'Invalid URL: blah'
+  const errorMessages = new RegExp(`${urlError1}|${urlError2}`)
+  expect(() => validateUrl('blah')).toThrow(errorMessages)
 })
 
 test('adds https:// to url if protocol is missing', () => {


### PR DESCRIPTION
Fixes #49 

**What**:

Switches `validates url is valid` test to use a regex that passes for changed `new URL()` error message from `node 15` to `node 16`


**Why**:

<!-- How were these changes implemented? -->
Test suite fails when asked to rerun all tests


**How**:

Pass a regex that will match the error message `Invalid URL` (error message node 16+) and `Invalid URL: blah` (error message node 15-) into the tests `toThrow()`.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation `N/A`
- [x] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
